### PR TITLE
add damped version of HMC code

### DIFF
--- a/scripts/PT_HMC_v5_damp.jl
+++ b/scripts/PT_HMC_v5_damp.jl
@@ -412,7 +412,7 @@ end
             timeP       = get(vars_restart, "timeP"  ,1)
             it          = get(vars_restart, "it"  ,1)
             it_tstep    = get(vars_restart, "it_tstep"  ,1)
-            do_restart = 0
+            do_restart  = false
         end
     	err_M = 2*tol; itp += 1
         timeP = timeP+dtp; push!(Time_vec, timeP)


### PR DESCRIPTION
I have added a new script in which damping is applied to Pf and Vx and Vy.
I have also introduced a pseudo-time stepping for Pt (there was none).
However I'm not sure if I should have broken actions in several kernels (for thread synchronisation). Maybe you can you review this part?
At least in runs on CPU for apparently provide expected scaling (double number of iterations for doubling of resolution).